### PR TITLE
Update for Wagtail 6.4

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,7 @@ jobs:
       matrix:
         python-version: ["3.9", "3.10", "3.11", "3.12", "3.13"]
         django-version: ["4.2", "5.0", "5.1"]
-        wagtail-version: ["5.2", "6.2", "6.3"]
+        wagtail-version: ["5.2", "6.2", "6.3", "6.4"]
         exclude:
           - python-version: "3.9"
             django-version: "5.0"


### PR DESCRIPTION
This pull request includes an update to the CI configuration file

* Added Wagtail version `6.4` to the testing matrix to include the latest version in the CI pipeline.