### PR TITLE
Update to support Wagtail 7.1

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,7 @@ jobs:
       matrix:
         python-version: ["3.9", "3.10", "3.11", "3.12", "3.13"]
         django-version: ["4.2", "5.1", "5.2"]
-        wagtail-version: ["6.3", "6.4", "7.0"]
+        wagtail-version: ["6.3", "7.0", "7.1"]
         exclude:
           # Django versions not compatible with python 3.9
           - python-version: "3.9"


### PR DESCRIPTION
Update to support Wagtail 7.1, only updates to the CI.

### Updates to test
- ci.yml
    - Added Wagtail 7.1 to versions, remove Wagtail 6.4 (EOL) 