### PR TITLE
Wagtail 7.2 maintenance

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,19 +13,24 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.9", "3.10", "3.11", "3.12", "3.13"]
+        python-version: ["3.10", "3.11", "3.12", "3.13", "3.14"]
         django-version: ["4.2", "5.1", "5.2"]
-        wagtail-version: ["6.3", "7.0", "7.1"]
+        wagtail-version: ["6.3", "7.0", "7.1", "7.2"]
         exclude:
-          # Django versions not compatible with python 3.9
-          - python-version: "3.9"
-            django-version: "5.1"
-          - python-version: "3.9"
-            django-version: "5.2"
 
-          # Django versions not compatible with python 3.13
-          - python-version: "3.13"
+          # Django versions not compatible with python 3.14
+          - python-version: "3.14"
             django-version: "4.2"
+          - python-version: "3.14"
+            django-version: "5.1"
+
+          # Wagtail versions not compatible with python 3.14
+          - python-version: "3.14"
+            wagtail-version: "6.3"
+          - python-version: "3.14"
+            wagtail-version: "7.0"
+          - python-version: "3.14"
+            wagtail-version: "7.1"
 
     steps:
       - uses: actions/checkout@v4

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,17 +22,17 @@ classifiers = [
     "Framework :: Django :: 5.2",
     "Development Status :: 5 - Production/Stable",
     "Programming Language :: Python :: 3",
-    "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
     "Programming Language :: Python :: 3.13",
+    "Programming Language :: Python :: 3.14",
     "Operating System :: OS Independent",
     "Topic :: Internet :: WWW/HTTP",
     "Topic :: Software Development",
     "Typing :: Typed"
 ]
-requires-python = ">=3.9"
+requires-python = ">=3.10"
 
 dependencies = [
     "wagtail>=6.3",


### PR DESCRIPTION
This pull request updates the project's Python version support, removing compatibility with Python 3.9 and adding support for Python 3.14. It also expands the test matrix to include new Wagtail and Django versions

**Python version support updates:**

* Removed support for Python 3.9 and added support for Python 3.14 in the `pyproject.toml` classifiers and set the minimum required Python version to 3.10.
* Updated the GitHub Actions CI matrix to test against Python 3.10–3.14, removing Python 3.9.