### PR TITLE
Pretty test names in CI matrix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,6 +10,7 @@ on:
 
 jobs:
   test:
+    name: "Python ${{ matrix.python-version }}, Django ${{ matrix.django-version }}, Wagtail ${{ matrix.wagtail-version }}"
     runs-on: ubuntu-latest
     strategy:
       matrix:


### PR DESCRIPTION
Make the test names more readable – "Python 3.9, Django 4.2, Wagtail 6.3" instead of "test (3.9, 4.2, 6.3)".