### PR TITLE
Drop Wagtail 6.3, add Wagtail 7.1 and 7.4 LTS to support matrix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,7 @@ jobs:
       matrix:
         python-version: ["3.10", "3.11", "3.12", "3.13", "3.14"]
         django-version: ["4.2", "5.2", "6.0"]
-        wagtail-version: ["6.3", "7.0", "7.2", "7.3"]
+        wagtail-version: ["7.0", "7.1", "7.2", "7.3", "7.4"]
         exclude:
 
           # Django versions not compatible with Python <3.12
@@ -31,26 +31,30 @@ jobs:
 
           # Wagtail versions not compatible with Python 3.14
           - python-version: "3.14"
-            wagtail-version: "6.3"
-          - python-version: "3.14"
             wagtail-version: "7.0"
+          - python-version: "3.14"
+            wagtail-version: "7.1"
 
           # Wagtail versions not compatible with Django 6.0
           - django-version: "6.0"
-            wagtail-version: "6.3"
-          - django-version: "6.0"
             wagtail-version: "7.0"
+          - django-version: "6.0"
+            wagtail-version: "7.1"
+
+          # Wagtail versions not compatible with Django 4.2
+          - django-version: "4.2"
+            wagtail-version: "7.4"
 
     steps:
       - uses: actions/checkout@v4
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
       - uses: actions/cache@v4
         with:
           path: ~/.cache/pip
-          key: ${{ runner.os }}-pip-${{ matrix.python-version }}-${{ hashFiles('setup.py') }}-${{ hashFiles('dev-requirements.txt') }}
+          key: ${{ runner.os }}-pip-${{ matrix.python-version }}-${{ hashFiles('pyproject.toml') }}
       - name: Install dependencies
         run: |
           python -m pip install --upgrade flit
@@ -77,7 +81,7 @@ jobs:
       with:
         fetch-depth: 0
     - name: Set up Python
-      uses: actions/setup-python@v4
+      uses: actions/setup-python@v5
       with:
         python-version: "3.13"
     - name: Install dependencies

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,7 +14,6 @@ classifiers = [
     "License :: OSI Approved",
     "License :: OSI Approved :: BSD License",
     "Framework :: Wagtail",
-    "Framework :: Wagtail :: 6",
     "Framework :: Wagtail :: 7",
     "Framework :: Django",
     "Framework :: Django :: 4.2",
@@ -35,7 +34,7 @@ classifiers = [
 requires-python = ">=3.10"
 
 dependencies = [
-    "wagtail>=6.3",
+    "wagtail>=7.0",
     "Django>=4.2"
 ]
 


### PR DESCRIPTION
## Summary
- Wagtail 6.3 LTS reached EOL on 2026-05-01 and is removed from the support range.
- Wagtail 7.4 LTS (released 2026-05-04) becomes the new top of the range; Wagtail 7.1 (previously missing from the matrix) is also added.
- Target support range is now Wagtail 7.0 LTS → 7.4 LTS, with Django 4.2/5.2/6.0 and Python 3.10–3.14 unchanged.

## Changes
- `pyproject.toml`: `wagtail>=6.3` → `wagtail>=7.0`; remove `Framework :: Wagtail :: 6` classifier.
- `.github/workflows/ci.yml`: matrix updated to `[7.0, 7.1, 7.2, 7.3, 7.4]`; add Django 4.2 × Wagtail 7.4 exclusion (Wagtail 7.4 dropped Django 4.2); bump `actions/setup-python` to v5; fix stale pip cache key.

No source code changes were required — `OEmbedFinder` and the `youtube` provider APIs are unchanged across the new range.

## Test plan
- [x] CI matrix passes on all `python × django × wagtail` combinations
- [x] `ruff format --check` and `ruff check` pass
- [x] `flit build` succeeds in the package job